### PR TITLE
Andrew fix editor add tokenizer dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "gobang"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,7 @@ dependencies = [
  "easy-cast",
  "futures",
  "itertools",
+ "libtok2me",
  "log",
  "log4rs",
  "pretty_assertions",
@@ -797,6 +798,17 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libtok2me"
+version = "0.1.0"
+source = "git+https://github.com/andyslucky/libtok2me#1eb448cc3df875c5fc78e0d6f2163cfb1a036297"
+dependencies = [
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_yaml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gobang"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 authors = ["Takayuki Maeda <takoyaki0316@gmail.com>", "Andrew Strickland <andrewpstrickland@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members=[
 ]
 
 [dependencies]
+libtok2me = {git = "https://github.com/andyslucky/libtok2me"}
 log4rs = {version = "1.0.0", features = ["file_appender"]}
 regex = "1.5.4"
 log = "0.4.14"

--- a/log4rs.yml
+++ b/log4rs.yml
@@ -6,6 +6,6 @@ appenders:
     kind: file
     path: "log/stdout.log"
 root:
-  level: debug
+  level: info
   appenders:
     - stdout

--- a/src/components/completion.rs
+++ b/src/components/completion.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use database_tree::{Child, Database, Table};
 use futures::try_join;
 use log::{debug, error};
 use tui::{
@@ -10,6 +9,8 @@ use tui::{
     widgets::{Block, Borders, Clear, List, ListItem, ListState},
     Frame,
 };
+
+use database_tree::{Child, Database, Table};
 
 use crate::components::command::CommandInfo;
 use crate::config::KeyConfig;
@@ -230,19 +231,22 @@ impl MovableComponent for CompletionComponent {
             let candidate_list = List::new(candidates)
                 .block(Block::default().borders(Borders::ALL))
                 .highlight_style(Style::default().bg(Color::Rgb(0xea, 0x59, 0x0b)))
-                .style(Style::default());
+                .style(Style::default().fg(Color::White));
 
-            let area = Rect::new(
-                x,
-                y,
-                width
-                    .min(f.size().width)
-                    .min(f.size().right().saturating_sub(area.x + x)),
-                (cand_len.min(5) as u16 + 2).min(f.size().bottom().saturating_sub(area.y + y + 2)),
-            );
-            f.render_widget(Clear, area);
+            let h =
+                (cand_len.min(5) as u16 + 2).min(f.size().bottom().saturating_sub(area.y + y + 2));
+
+            let w = width.min(f.size().width);
+            let max_x = f.size().right().min(area.right());
+            let max_y = f.size().bottom();
+            let y = if y >= max_y { max_y } else { y };
+            let x = if x >= max_x { max_x } else { x };
+            let comp_area = Rect::new(if x + w > max_x { max_x - w } else { x }, y, w, h);
             let mut st = self.state.clone();
-            f.render_stateful_widget(candidate_list, area, &mut st);
+            if comp_area.bottom() <= f.size().bottom() {
+                f.render_widget(Clear, comp_area);
+                f.render_stateful_widget(candidate_list, comp_area, &mut st);
+            }
         }
         Ok(())
     }
@@ -257,10 +261,10 @@ impl Component for CompletionComponent {
         key: crate::event::Key,
         _message_queue: &mut crate::app::GlobalMessageQueue,
     ) -> Result<EventState> {
-        if key == self.key_config.move_down {
+        if key == self.key_config.move_down && self.is_visible() {
             self.next();
             return Ok(EventState::Consumed);
-        } else if key == self.key_config.move_up {
+        } else if key == self.key_config.move_up && self.is_visible() {
             self.previous();
             return Ok(EventState::Consumed);
         }
@@ -268,7 +272,7 @@ impl Component for CompletionComponent {
     }
 
     fn is_visible(&self) -> bool {
-        return !self.word.is_empty();
+        return !self.word.is_empty() && !self.candidates.is_empty();
     }
 
     fn reset(&mut self) {

--- a/src/components/completion.rs
+++ b/src/components/completion.rs
@@ -136,7 +136,7 @@ impl FilterableCompletionSource for DefaultFilterableCompletionSource {
             .filter(|kw| patt.is_match(kw.as_str()))
             .map(|kw| kw.clone())
             .collect();
-        debug!("Filtered candidates {:?}", candidates);
+        // debug!("Filtered candidates {:?}", candidates);
         return Ok(candidates);
     }
 }
@@ -170,7 +170,7 @@ impl CompletionComponent {
         if let Err(e) = &candidates_res {
             error!("Error fetching completion candidates {}", e);
         } else if let Ok(candidates) = &candidates_res {
-            debug!("Filtered candidates {:?}", candidates);
+            // debug!("Filtered candidates {:?}", candidates);
             self.candidates = candidates.clone();
             if !self.candidates.is_empty() {
                 self.state.select(Some(0));

--- a/src/components/error.rs
+++ b/src/components/error.rs
@@ -76,7 +76,7 @@ impl Component for ErrorComponent {
                 self.hide();
                 return Ok(EventState::Consumed);
             }
-            return Ok(EventState::NotConsumed);
+            return Ok(EventState::Consumed);
         }
         Ok(EventState::NotConsumed)
     }

--- a/src/components/sql_editor.rs
+++ b/src/components/sql_editor.rs
@@ -3,19 +3,19 @@ use async_trait::async_trait;
 use log::info;
 use tui::{
     backend::Backend,
-    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
     widgets::{Block, Borders, Paragraph, Wrap},
+    Frame,
 };
 use unicode_width::UnicodeWidthStr;
 
 use crate::app::{AppMessage, AppStateRef, GlobalMessageQueue};
-use crate::components::{Drawable, DrawableComponent};
 use crate::components::command::CommandInfo;
 use crate::components::databases::DatabaseEvent;
-use crate::components::EventState::{Consumed, NotConsumed};
 use crate::components::tab::{Tab, TabType};
+use crate::components::EventState::{Consumed, NotConsumed};
+use crate::components::{Drawable, DrawableComponent};
 use crate::config::KeyConfig;
 use crate::database::ExecuteResult;
 use crate::event::Key;
@@ -25,7 +25,7 @@ use crate::ui::stateful_paragraph::{ParagraphState, StatefulParagraph};
 use crate::ui::textarea::TextArea;
 
 use super::{
-    CompletionComponent, Component, compute_character_width, EventState, MovableComponent,
+    compute_character_width, CompletionComponent, Component, EventState, MovableComponent,
     TableComponent,
 };
 
@@ -75,8 +75,6 @@ impl SqlEditorComponent {
         app_state: AppStateRef,
         editor_name: Option<String>,
     ) -> Self {
-        // TODO: Move into text editor component
-       
         Self {
             text_area: TextArea::new(key_config.clone(), app_state.clone()).await,
             table: TableComponent::new(key_config.clone()),
@@ -176,7 +174,6 @@ impl Component for SqlEditorComponent {
         key: crate::event::Key,
         message_queue: &mut GlobalMessageQueue,
     ) -> Result<EventState> {
-
         return match self.focus {
             Focus::Editor => self.editor_key_event(key, message_queue).await,
             Focus::Table => {
@@ -187,5 +184,10 @@ impl Component for SqlEditorComponent {
                 self.table.event(key, message_queue).await
             }
         };
+    }
+
+    async fn handle_messages(&mut self, messages: &Vec<Box<dyn AppMessage>>) -> Result<()> {
+        self.text_area.handle_messages(messages).await?;
+        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 use std::io;
 
 use anyhow::Result;
@@ -48,13 +50,13 @@ async fn main() -> anyhow::Result<()> {
         match events.next()? {
             Event::Input(key) => match app.event(key).await {
                 Ok(state) => {
-                    debug!(
-                        "Key pressed {:?} state consumed {}. Quit key {:?} exit key {:?}",
-                        key,
-                        state.is_consumed(),
-                        app.config.key_config.quit,
-                        app.config.key_config.exit
-                    );
+                    // debug!(
+                    //     "Key pressed {:?} state consumed {}. Quit key {:?} exit key {:?}",
+                    //     key,
+                    //     state.is_consumed(),
+                    //     app.config.key_config.quit,
+                    //     app.config.key_config.exit
+                    // );
                     if !state.is_consumed()
                         && (key == app.config.key_config.quit
                             || key == Key::Ctrl(crossterm::event::KeyCode::Char('c'))

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod components;
 mod config;
 mod database;
 mod event;
+mod saturating_types;
 mod sql_utils;
 mod ui;
 mod version;

--- a/src/saturating_types.rs
+++ b/src/saturating_types.rs
@@ -23,6 +23,45 @@ impl Into<usize> for SaturatingU16 {
     }
 }
 
+impl PartialEq<SaturatingU16> for SaturatingU16 {
+    fn eq(&self, other: &SaturatingU16) -> bool {
+       return self.0 == other.0;
+    }
+
+    fn ne(&self, other: &SaturatingU16) -> bool {
+        return self.0 != other.0;
+    }
+}
+
+impl PartialOrd<SaturatingU16> for SaturatingU16 {
+    fn partial_cmp(&self, other: &SaturatingU16) -> Option<Ordering> {
+        if self.0 < other.0 {
+            Some(Ordering::Less)
+        } else if self.0 > other.0 {
+            Some(Ordering::Greater)
+        } else {
+            Some(Ordering::Equal)
+        }
+    }
+
+    fn lt(&self, other: &SaturatingU16) -> bool {
+        return self.0 < other.0;
+    }
+
+    fn le(&self, other: &SaturatingU16) -> bool {
+        return self.0 <= other.0;
+    }
+
+    fn gt(&self, other: &SaturatingU16) -> bool {
+        return self.0 > other.0;
+    }
+
+    fn ge(&self, other: &SaturatingU16) -> bool {
+        return self.0 >= other.0;
+    }
+}
+
+
 impl PartialEq<u16> for SaturatingU16 {
     fn eq(&self, other: &u16) -> bool {
         return self.0 == *other;

--- a/src/saturating_types.rs
+++ b/src/saturating_types.rs
@@ -1,0 +1,86 @@
+/// Module for types whose operations saturate at bounds instead of panic.
+use std::cmp::Ordering;
+use std::ops;
+
+#[derive(Clone, Copy)]
+pub struct SaturatingU16(pub u16);
+
+impl Into<SaturatingU16> for u16 {
+    fn into(self) -> SaturatingU16 {
+        return SaturatingU16(self);
+    }
+}
+
+impl Into<u16> for SaturatingU16 {
+    fn into(self) -> u16 {
+        return self.0;
+    }
+}
+
+impl Into<usize> for SaturatingU16 {
+    fn into(self) -> usize {
+        return self.0 as usize;
+    }
+}
+
+impl PartialEq<u16> for SaturatingU16 {
+    fn eq(&self, other: &u16) -> bool {
+        return self.0 == *other;
+    }
+
+    fn ne(&self, other: &u16) -> bool {
+        return self.0 != *other;
+    }
+}
+impl PartialOrd<u16> for SaturatingU16 {
+    fn partial_cmp(&self, other: &u16) -> Option<Ordering> {
+        if self.0 < *other {
+            Some(Ordering::Less)
+        } else if self.0 > *other {
+            Some(Ordering::Greater)
+        } else {
+            Some(Ordering::Equal)
+        }
+    }
+
+    fn lt(&self, other: &u16) -> bool {
+        return self.0 < *other;
+    }
+
+    fn le(&self, other: &u16) -> bool {
+        return self.0 <= *other;
+    }
+
+    fn gt(&self, other: &u16) -> bool {
+        return self.0 > *other;
+    }
+
+    fn ge(&self, other: &u16) -> bool {
+        return self.0 >= *other;
+    }
+}
+impl ops::AddAssign<u16> for SaturatingU16 {
+    fn add_assign(&mut self, rhs: u16) {
+        self.0 = self.0.saturating_add(rhs);
+    }
+}
+
+impl ops::SubAssign<u16> for SaturatingU16 {
+    fn sub_assign(&mut self, rhs: u16) {
+        self.0 = self.0.saturating_sub(rhs);
+    }
+}
+
+impl ops::Add<u16> for SaturatingU16 {
+    type Output = SaturatingU16;
+    fn add(self, rhs: u16) -> Self::Output {
+        return SaturatingU16(self.0.saturating_add(rhs));
+    }
+}
+
+impl ops::Sub<u16> for SaturatingU16 {
+    type Output = SaturatingU16;
+    fn sub(self, rhs: u16) -> Self::Output {
+        return SaturatingU16(self.0.saturating_sub(rhs));
+    }
+}

--- a/src/sql_utils.rs
+++ b/src/sql_utils.rs
@@ -1,8 +1,16 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug)]
 pub struct PatternPosition {
     pub index: usize,
     pub length: usize,
 }
 
+impl Display for PatternPosition {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
 macro_rules! find_separators {
     ($input : expr, $separators: expr) => {
         $separators
@@ -20,8 +28,8 @@ pub fn find_first_separator(input: &String) -> Option<PatternPosition> {
     val
 }
 
-pub fn find_last_separator(input: &String) -> Option<PatternPosition> {
+pub fn find_last_separator<S: Into<String>>(input: S) -> Option<PatternPosition> {
     let pattern = regex::Regex::new(r#"\W+"#).unwrap();
-    let val = find_separators!(input, pattern).last();
+    let val = find_separators!(input.into(), pattern).last();
     val
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,6 +8,7 @@ pub mod scrollbar;
 pub mod scrolllist;
 pub mod stateful_paragraph;
 pub mod syntax_text;
+pub mod textarea;
 pub mod textbox;
 
 pub fn common_nav(key: Key, key_config: &KeyConfig) -> Option<MoveSelection> {

--- a/src/ui/textarea.rs
+++ b/src/ui/textarea.rs
@@ -1,0 +1,309 @@
+use anyhow::Result;
+
+use async_trait::async_trait;
+use crossterm::event::KeyCode;
+use tui::backend::Backend;
+use tui::layout::Rect;
+use tui::style::{Color, Style};
+use tui::text::{Spans, Text};
+use tui::widgets::{Block, Borders, Paragraph};
+use tui::Frame;
+
+use crate::app::{AppMessage, AppStateRef, GlobalMessageQueue};
+use crate::components::databases::DatabaseEvent;
+use crate::components::EventState::{Consumed, NotConsumed};
+use crate::components::{CommandInfo, DrawableComponent, EventState};
+use crate::components::{CompletionComponent, Component};
+use crate::config::KeyConfig;
+use crate::saturating_types::SaturatingU16;
+use crate::{handle_message, Key};
+
+#[derive(Clone)]
+struct CursorPos {
+    row: SaturatingU16,
+    col: SaturatingU16,
+}
+
+impl Into<(u16, u16)> for CursorPos {
+    fn into(self) -> (u16, u16) {
+        (self.row.into(), self.col.into())
+    }
+}
+
+pub struct TextArea {
+    buffer: Vec<String>,
+    app_state: AppStateRef,
+    completion: CompletionComponent,
+    cursor_position: CursorPos,
+}
+
+impl TextArea {
+    pub async fn new(key_config: KeyConfig, app_state: AppStateRef) -> TextArea {
+        let mut completion = CompletionComponent::new(key_config.clone());
+        if let Some(src) = app_state.clone().read().await.pool_completion_src().await {
+            completion.completion_source = Box::new(src);
+        }
+        return TextArea {
+            buffer: Vec::new(),
+            completion,
+            app_state,
+            cursor_position: CursorPos {
+                row: 0.into(),
+                col: 0.into(),
+            },
+        };
+    }
+
+    pub fn get_text(&self) -> String {
+        return self.buffer.join("\n");
+    }
+
+    /// Get input as vec of spans converted into text. Each 'Spans' element is composed of multiple
+    /// graphemes each with their own symbol, style, and modifiers. Text encapsulates a vec of spans;
+    /// so we convert the vector of spans into a text before returning.
+    fn lines_as_text_model(&self) -> Text {
+        // TODO : Add different styling/highlights to keywords
+        // let lines: Vec<Spans> = self.buffer.split('\n').map(|l| Spans::from(l)).collect();
+        let lines: Vec<Spans> = self
+            .buffer
+            .iter()
+            .map(|l| Spans::from(l.as_str()))
+            .collect();
+        Text::from(lines)
+    }
+}
+
+impl DrawableComponent for TextArea {
+    fn draw<B: Backend>(&self, f: &mut Frame<B>, area: Rect, focused: bool) -> anyhow::Result<()> {
+        let row = self.cursor_position.row.0;
+        let col = self.cursor_position.col.0;
+        let block = Block::default().borders(Borders::ALL).style(if focused {
+            Style::default()
+        } else {
+            Style::default().fg(Color::DarkGray)
+        });
+        let text_area_frame = block.inner(area);
+        f.render_widget(block, area);
+
+        let p = Paragraph::new(self.lines_as_text_model())
+            .scroll((
+                0, // TODO: Fix row scrolling
+                if col > text_area_frame.width {
+                    col - text_area_frame.width
+                } else {
+                    0
+                },
+            ))
+            .style(if !focused {
+                Style::default().fg(Color::DarkGray)
+            } else {
+                Style::default()
+            });
+        f.render_widget(p, text_area_frame);
+        if focused {
+            f.set_cursor(
+                text_area_frame.x
+                    + if col > text_area_frame.width {
+                        text_area_frame.width
+                    } else {
+                        col
+                    },
+                text_area_frame.y
+                    + if row > text_area_frame.height {
+                        text_area_frame.height
+                    } else {
+                        row
+                    },
+            );
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Component for TextArea {
+    fn commands(&self, out: &mut Vec<CommandInfo>) {}
+
+    async fn event(
+        &mut self,
+        key: Key,
+        _message_queue: &mut GlobalMessageQueue,
+    ) -> anyhow::Result<EventState> {
+        // TODO: Move this logic to a TextAreaModel
+        let col = self.cursor_position.col.clone();
+        let row = self.cursor_position.row.clone();
+        let curr_line_length = self
+            .buffer
+            .get(row.0 as usize)
+            .map(|l| l.len() as u16)
+            .unwrap_or(0);
+        let last_line_length = self
+            .buffer
+            .get((row - 1).0 as usize)
+            .map(|l| l.len() as u16)
+            .unwrap_or(0);
+
+        if let Key::Char(c) = key {
+            let current_line: &mut String = {
+                //get current line (corresponds to the
+                if let Some(line) = self.buffer.get_mut(row.0 as usize) {
+                    line
+                } else {
+                    self.buffer.push(String::new());
+                    self.buffer.last_mut().unwrap()
+                }
+            };
+            current_line.insert(col.0 as usize, c);
+
+            self.cursor_position.col += 1;
+            return Ok(Consumed);
+        }
+
+        if key == Key::Enter {
+            let mut new_line: String;
+            if col < curr_line_length {
+                let line_remainder = self
+                    .buffer
+                    .get_mut(row.0 as usize)
+                    .map(|l| l.drain(col.0 as usize..l.len()).collect())
+                    .unwrap_or(String::from(""));
+                new_line = line_remainder;
+            } else {
+                new_line = String::new();
+            }
+            self.buffer.insert((row + 1).0 as usize, new_line);
+            self.cursor_position.col = 0.into();
+            self.cursor_position.row += 1;
+            return Ok(Consumed);
+        }
+
+        if key == Key::Delete {
+            if col < curr_line_length {
+                if let Some(current_line) = self.buffer.get_mut(row.0 as usize) {
+                    current_line.remove(col.0 as usize);
+                    return Ok(Consumed);
+                }
+            } else {
+                // TODO : Handle line wrapping del
+            }
+        }
+
+        if key == Key::Home && col != 0 {
+            self.cursor_position.col = 0.into();
+            return Ok(Consumed);
+        }
+
+        if key == Key::Ctrl(KeyCode::Home) {
+            self.cursor_position.row = 0.into();
+            self.cursor_position.col = 0.into();
+            return Ok(Consumed);
+        }
+
+        if key == Key::Ctrl(KeyCode::End) {
+            self.cursor_position.row = ((self.buffer.len() - 1) as u16).into();
+            self.cursor_position.col = self
+                .buffer
+                .last()
+                .map(|l| l.len() as u16)
+                .unwrap_or(0)
+                .into();
+            return Ok(Consumed);
+        }
+        if key == Key::End && col < curr_line_length {
+            self.cursor_position.col = curr_line_length.into();
+            return Ok(Consumed);
+        }
+
+        if key == Key::Backspace {
+            if col == 0 && (row - 1) < last_line_length {
+                let current_line = self.buffer.pop().unwrap_or(String::new());
+                if let Some(prev_line) = self.buffer.get_mut((row - 1).0 as usize) {
+                    prev_line.insert_str(last_line_length as usize, current_line.as_str());
+                    self.cursor_position.col = last_line_length.into();
+                    self.cursor_position.row -= 1;
+                    return Ok(Consumed);
+                }
+            } else if let Some(current_line) = self.buffer.get_mut(row.0 as usize) {
+                if current_line.is_empty() {
+                    self.buffer.pop();
+                    if let Some(prev_line_length) = self.buffer.last().map(|l| l.len() as u16) {
+                        self.cursor_position.col = prev_line_length.into();
+                        self.cursor_position.row -= 1;
+                    }
+                    return Ok(Consumed);
+                } else if ((col - 1).0 as usize) < current_line.len() {
+                    current_line.remove((col - 1).0 as usize);
+                    self.cursor_position.col -= 1;
+                    return Ok(Consumed);
+                }
+            }
+        }
+
+        if key == Key::Left {
+            if col == 0 && row > 0 {
+                self.cursor_position.col = self
+                    .buffer
+                    .get((row - 1).0 as usize)
+                    .map(|l| l.len() as u16)
+                    .unwrap_or(0)
+                    .into();
+                self.cursor_position.row -= 1;
+                return Ok(Consumed);
+            } else if col > 0 {
+                self.cursor_position.col -= 1;
+                return Ok(Consumed);
+            }
+        }
+
+        if key == Key::Right {
+            if col == curr_line_length && (row.0 as usize) < self.buffer.len().saturating_sub(1) {
+                self.cursor_position.col = 0.into();
+                self.cursor_position.row += 1;
+                return Ok(Consumed);
+            } else if col < curr_line_length {
+                self.cursor_position.col += 1;
+                return Ok(Consumed);
+            }
+        }
+
+        if key == Key::Up {
+            if row > 0 {
+                self.cursor_position.row -= 1;
+
+                if col > last_line_length {
+                    self.cursor_position.col = last_line_length.into();
+                }
+                return Ok(Consumed);
+            }
+        }
+
+        if key == Key::Down {
+            if (row.0 as usize) < (self.buffer.len().saturating_sub(1)) {
+                self.cursor_position.row += 1;
+                let last_line_length = self
+                    .buffer
+                    .get(row.0 as usize)
+                    .map(|l| l.len() as u16)
+                    .unwrap_or(0);
+                if col > last_line_length {
+                    self.cursor_position.col = last_line_length.into();
+                }
+                return Ok(Consumed);
+            }
+        }
+
+        Ok(NotConsumed)
+    }
+
+    async fn handle_messages(&mut self, messages: &Vec<Box<dyn AppMessage>>) -> Result<()> {
+        for m in messages.iter() {
+            handle_message!(m,DatabaseEvent, DatabaseEvent::TableSelected(_, _) => {
+
+                if let Some(src) = self.app_state.read().await.pool_completion_src().await {
+                    self.completion.completion_source = Box::new(src);
+                }
+            });
+        }
+        Ok(())
+    }
+}

--- a/src/ui/textbox.rs
+++ b/src/ui/textbox.rs
@@ -293,6 +293,14 @@ impl DrawableComponent for TextBox {
             },
             w = text_rect.width as usize
         )))
+        .scroll((
+            0,
+            if self.input_cursor_position > (text_rect.width as usize) {
+                self.input_cursor_position as u16 - text_rect.width
+            } else {
+                0
+            },
+        ))
         .style(if focused && !self.input.is_empty() {
             Style::default()
         } else {

--- a/src/ui/textbox.rs
+++ b/src/ui/textbox.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use crossterm::event;
 use crossterm::event::KeyCode;
+use std::borrow::Borrow;
 use tui::backend::Backend;
 use tui::layout::{Constraint, Direction, Layout, Margin, Rect};
 use tui::style::{Color, Style};
@@ -121,9 +122,17 @@ impl TextBox {
             .map(|index| compute_character_width(&self.input[index as usize]) as usize)
             .sum::<usize>()
             + label_length;
-        let cursor_y_pos = area.y + (area.height / 2);
-
-        return ((area.x + curs_x_offset as u16) + 1, cursor_y_pos);
+        let cursor_y_pos = if area.height == 1 {
+            area.y
+        } else {
+            area.y + (area.height / 2)
+        };
+        let cursor_x_pos = if (area.x + curs_x_offset as u16) + 1 >= area.right() {
+            area.right()
+        } else {
+            area.x + curs_x_offset as u16 + 1
+        };
+        return (cursor_x_pos, cursor_y_pos);
     }
 
     /// Replaces the text between the last separator and the cursor with the arg `text`
@@ -252,7 +261,6 @@ impl DrawableComponent for TextBox {
             0
         };
 
-        // TODO: Implement text-align
         let text_field_block = Block::default().borders(Borders::ALL).style(if focused {
             Style::default()
         } else {


### PR DESCRIPTION
changelog:
- Created a multiline textarea widget. This widget scrolls its content and keypresses may wrap around lines (e.g. using left arrow at beginning of a line)
- Added completion functionality, with plans to improve completion order and decisions.
- Text boxes now scroll as the user types of presses arrow keys
- Error component now prevents key presses from being handled by other components as a conventional modal should.
- Created a `saturating_types` module for types that saturate ops on their bounds.
